### PR TITLE
Added function to delete the linked list

### DIFF
--- a/lib/HTML_code_doubly_linked_list.c
+++ b/lib/HTML_code_doubly_linked_list.c
@@ -96,13 +96,15 @@ void insert_tag(char *name, char *param)
 
 void insert_text(char *text)
 {
+    char *dynamic_text = malloc(sizeof(char) * strlen(text));
+    strcpy(dynamic_text, text);
     if(_HTML_START_ != NULL)
     {
-        HTML_CODE *field_start = create_HTML_CODE(text, _HTML_CURRENT_, (*_HTML_CURRENT_).next);
+        HTML_CODE *field_start = create_HTML_CODE(dynamic_text, _HTML_CURRENT_, (*_HTML_CURRENT_).next);
     }
     else
     {
-        HTML_CODE *line = create_HTML_CODE(text, NULL, NULL);
+        HTML_CODE *line = create_HTML_CODE(dynamic_text, NULL, NULL);
         _HTML_START_ = line;
     }
 }
@@ -112,4 +114,17 @@ void exit_field(int count)
     for(int i = 0; i < count; i++) {
         _HTML_CURRENT_ = (*_HTML_CURRENT_).next;
     }
+}
+
+void delete_code()
+{
+    HTML_CODE *next_node;
+    while(_HTML_START_ != NULL)
+    {
+        next_node = _HTML_START_->next;
+        free(_HTML_START_->text);
+        free(_HTML_START_);
+        _HTML_START_ = next_node;
+    }
+    _HTML_CURRENT_ = NULL;
 }

--- a/lib/HTML_code_doubly_linked_list.h
+++ b/lib/HTML_code_doubly_linked_list.h
@@ -12,9 +12,6 @@ typedef struct HTML_CODE
     struct HTML_CODE *next;
 } HTML_CODE;
 
-extern HTML_CODE *_HTML_START_;
-extern HTML_CODE *_HTML_CURRENT_;
-
 void generate_html_file(char *file_name);
 
 HTML_CODE *create_HTML_CODE(char *text, HTML_CODE *previous, HTML_CODE *next);
@@ -24,5 +21,7 @@ void insert_tag(char *name, char *param);
 void insert_text(char *text);
 
 void exit_field(int count);
+
+void delete_code();
 
 #endif

--- a/lib/main.c
+++ b/lib/main.c
@@ -16,6 +16,7 @@ int main()
     char *file_name = "output.txt";
     generate_html_file(file_name);
     printf("File printed\n");
+    delete_code();
     return 0;
 }
 


### PR DESCRIPTION
Added function to delete the linked list. Global variables can now be only accessed in the list source file. insert text now dynamically allocates the text, so it can't be deleted by original variable going out of scope and can be deleted by the delete function.